### PR TITLE
feat: Implement simple dynamic routing framework

### DIFF
--- a/router/demo.go
+++ b/router/demo.go
@@ -6,7 +6,13 @@ import (
 	"github.com/zzzgydi/webscraper/router/middleware"
 )
 
-func DemoRouter(r *gin.Engine) {
+func init() {
+	RegisterRoute(func(r *gin.Engine) {
+		demoRouter(r)
+	})
+}
+
+func demoRouter(r *gin.Engine) {
 	r.LoadHTMLGlob("static/*")
 	r.GET("/", middleware.LoggerMiddleware, controller.GetScrapeHTML)
 }

--- a/router/health.go
+++ b/router/health.go
@@ -4,7 +4,13 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func HealthRouter(r *gin.Engine) {
+func init() {
+	RegisterRoute(func(r *gin.Engine) {
+		healthRouter(r)
+	})
+}
+
+func healthRouter(r *gin.Engine) {
 	r.GET("/health", func(c *gin.Context) {
 		c.String(200, "ok")
 	})

--- a/router/init.go
+++ b/router/init.go
@@ -12,6 +12,19 @@ import (
 	L "github.com/zzzgydi/webscraper/common/logger"
 )
 
+var registry []func(*gin.Engine)
+
+// RegisterRoute Register router api
+func RegisterRoute(registerFunc func(*gin.Engine)) {
+	registry = append(registry, registerFunc)
+}
+
+func initRoutes(r *gin.Engine) {
+	for _, register := range registry {
+		register(r)
+	}
+}
+
 func InitHttpServer() {
 	r := gin.New()
 	r.Use(gin.Recovery())
@@ -28,9 +41,7 @@ func InitHttpServer() {
 	}))
 
 	// register routers
-	DemoRouter(r)
-	HealthRouter(r)
-	InnerRouter(r)
+	initRoutes(r)
 
 	logger := slog.NewLogLogger(L.Handler, slog.LevelError)
 	srv := &http.Server{

--- a/router/scrape.go
+++ b/router/scrape.go
@@ -6,7 +6,13 @@ import (
 	"github.com/zzzgydi/webscraper/router/middleware"
 )
 
-func InnerRouter(r *gin.Engine) {
+func init() {
+	RegisterRoute(func(r *gin.Engine) {
+		innerRouter(r)
+	})
+}
+
+func innerRouter(r *gin.Engine) {
 	v1 := r.Group("/v1")
 	v1.Use(middleware.LoggerMiddleware)
 


### PR DESCRIPTION
# Issue

在原本的设计中，每次需要新增路由的时候，都需要修改init.go之中的代码：
```
func InitHttpServer() {
        ......

	// register routers
	DemoRouter(r)
	HealthRouter(r)
	InnerRouter(r)

        ........
}
```

我引入了一个公共的路由注册方法，每次新增路由的时候，只需要调用RegisterRoute方法将路由进行注册即可。这样的实现不需要修改 init.go 之中的代码：
```
var registry []func(*gin.Engine)

// RegisterRoute Register router api
func RegisterRoute(registerFunc func(*gin.Engine)) {
	registry = append(registry, registerFunc)
}

func initRoutes(r *gin.Engine) {
	for _, register := range registry {
		register(r)
	}
}

func InitHttpServer() {
        ......

	// register routers
        initRoutes(r)

        ........
}
```
修改后，demo.go 路由实现如下：
```
func init() {
	RegisterRoute(func(r *gin.Engine) {
		demoRouter(r)
	})
}

func demoRouter(r *gin.Engine) {
	r.LoadHTMLGlob("static/*")
	r.GET("/", middleware.LoggerMiddleware, controller.GetScrapeHTML)
}

```
依赖于 init 方法将路由进行注册